### PR TITLE
replacing python shebangs

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -15,6 +15,7 @@ MinContigHitFrac=0.9
 # What do you have to type into the command line to make these commands execute?
 # (If the binary file lives in a directory that is not included in your $PATH
 # variable, you will need to include the path here.)
+Python='/usr/bin/env python2'
 BlastDBcommand='makeblastdb'
 BlastNcommand='blastn'
 smalt='smalt'

--- a/shiver_align_contigs.sh
+++ b/shiver_align_contigs.sh
@@ -92,7 +92,7 @@ PrintAlnLengthIncrease "$RefAlignment" "$RawContigAlignment" || \
 "contigs to the existing references. Quitting." >&2 ; exit 1 ; }
 
 # Run the contig cutting & flipping code
-"$Code_CorrectContigs" "$BlastFile" "$ContigMinBlastOverlapToMerge" \
+$Python "$Code_CorrectContigs" "$BlastFile" "$ContigMinBlastOverlapToMerge" \
 -C "$ContigFile" -O "$CutContigFile" -B "$MergedBlastFile" || \
 { echo "Problem encountered running $Code_CorrectContigs. Quitting." >&2 ; \
 exit 1; }
@@ -117,7 +117,7 @@ if [[ -f "$CutContigFile" ]]; then
 
   # Split gappy contigs after alignment.
   CutContigNames=$(awk '/^>/ {print substr($1,2)}' "$CutContigFile")
-  "$Code_CutAlignedContigs" "$TempContigAlignment3" $CutContigNames \
+  $Python "$Code_CutAlignedContigs" "$TempContigAlignment3" $CutContigNames \
   $CutAlignedContigsArgs > "$CutContigAlignment"
   CutAlignedContigsStatus=$?
   if [[ $CutAlignedContigsStatus == 3 ]]; then
@@ -138,7 +138,7 @@ else
   # want to split the aligned raw contigs. If so, name it the same as aligned
   # cut contigs for consistency.
   RawContigNames=$(awk '/^>/ {print substr($1,2)}' "$RawContigFile1")
-  "$Code_CutAlignedContigs" "$RawContigAlignment" $RawContigNames \
+  $Python "$Code_CutAlignedContigs" "$RawContigAlignment" $RawContigNames \
   $CutAlignedContigsArgs > "$CutContigAlignment"
   CutAlignedContigsStatus=$?
   if [[ $CutAlignedContigsStatus == 3 ]]; then
@@ -150,7 +150,7 @@ else
     exit 1
   fi
 
-  equal=$("$Code_CheckFastaFileEquality" "$RawContigAlignment" \
+  equal=$($Python "$Code_CheckFastaFileEquality" "$RawContigAlignment" \
   "$CutContigAlignment") || { echo "Problem running"\
   "$Code_CheckFastaFileEquality. Quitting." >&2 ; exit 1 ; }
   if [[ "$equal" == "true" ]]; then

--- a/shiver_full_auto.sh
+++ b/shiver_full_auto.sh
@@ -61,7 +61,7 @@ HIVcontigNames=$(awk '/^>/ {print substr($1,2)}' "$RawContigFile1")
 
 # Run the contig cutting & flipping code. Check it works, and quit if it thinks
 # the contigs need correcting.
-"$Code_CorrectContigs" "$BlastFile" --min-hit-frac "$MinContigHitFrac" || \
+$Python "$Code_CorrectContigs" "$BlastFile" --min-hit-frac "$MinContigHitFrac" || \
 { echo "The contigs in $ContigFile appear to need correcting (or a problem" \
 "was encountered running $Code_CorrectContigs; check any error messages" \
 "above). Fully automatic processing not possible. Quitting." >&2 ; exit 1 ; }
@@ -93,7 +93,7 @@ for ref in "$InitDir"/'IndividualRefs'/*'.fasta'; do
     echo "Error: unexpected whitespace in file $AlnFile1. Quitting." >&2
     exit 1
   fi
-  RefSimilarityScore1=$("$Code_ConstructRef" "$AlnFile1" 'DummyOut' \
+  RefSimilarityScore1=$($Python "$Code_ConstructRef" "$AlnFile1" 'DummyOut' \
   $HIVcontigNames --print-best-score | awk '{print $1}')
   echo $RefSimilarityScore1 "$AlnFile1" >> "$RefMatchLog"
 
@@ -110,7 +110,7 @@ for ref in "$InitDir"/'IndividualRefs'/*'.fasta'; do
   OldMafft=true
   rm "$AlnFile2"
   continue ; }
-  RefSimilarityScore2=$("$Code_ConstructRef" "$AlnFile2" 'DummyOut' \
+  RefSimilarityScore2=$($Python "$Code_ConstructRef" "$AlnFile2" 'DummyOut' \
   $HIVcontigNames --print-best-score | awk '{print $1}')
   echo $RefSimilarityScore2 "$AlnFile2" >> "$RefMatchLog"
 
@@ -123,7 +123,7 @@ mv "$BestRefFile" "$BestContigToRefAlignment"
 
 # Check that the gappiest contig is not too gappy in the best contig-to-ref
 # alignment.
-LargestGapFrac=$("$Code_ConstructRef" "$BestContigToRefAlignment" 'DummyOut' \
+LargestGapFrac=$($Python "$Code_ConstructRef" "$BestContigToRefAlignment" 'DummyOut' \
 $HIVcontigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}')
 if (( $(echo "$LargestGapFrac > $MaxContigGappiness" | bc -l) )); then
   echo "The gappiest contig in the best contig-to-reference alignment," \
@@ -145,7 +145,7 @@ fi
 #fi
 
 # Construct the tailored ref
-"$Code_ConstructRef" "$BestContigToRefAlignment" "$GappyRefWithExtraSeq" \
+$Python "$Code_ConstructRef" "$BestContigToRefAlignment" "$GappyRefWithExtraSeq" \
 $HIVcontigNames ||
 { echo 'Failed to construct a ref from the alignment. Quitting.' >&2; exit 1 ; }
 
@@ -153,7 +153,7 @@ $HIVcontigNames ||
 awk '/^>/{if(N)exit;++N;} {print;}' "$GappyRefWithExtraSeq" > "$RefWithGaps"
 
 # Remove any gaps from the reference
-"$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
+$Python "$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
 { echo 'Gap stripping code failed. Quitting.' >&2 ; exit 1 ; }
 
 # Map!

--- a/shiver_funcs.sh
+++ b/shiver_funcs.sh
@@ -50,11 +50,11 @@ function AlignContigsToRefs {
   "$TempContigAlignment1" || \
   { echo 'Problem aligning' "$ContigFile"'.' >&2 ; return 1 ; }
   if [[ $MafftTestingStrategy == "MinAlnLength" ]]; then
-    PenaltyForAdd=$("$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+    PenaltyForAdd=$($Python "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
     "$TempContigAlignment1" | awk '{print $2}') || { echo "Problem running"\
     "$Code_PrintSeqLengths." >&2 ; return 1 ; }
   elif [[ $MafftTestingStrategy == "MinMaxGappiness" ]]; then
-    PenaltyForAdd=$("$Code_ConstructRef" "$TempContigAlignment1" 'DummyOut' \
+    PenaltyForAdd=$($Python "$Code_ConstructRef" "$TempContigAlignment1" 'DummyOut' \
     $ContigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}') || { echo 'Problem'\
     "analysing $TempContigAlignment1 (i.e. the output from aligning $ContigFile"\
     "and $ThisRefAlignment) with $Code_ConstructRef." >&2 ; return 1 ; }
@@ -77,11 +77,11 @@ function AlignContigsToRefs {
 
       # ...however if addfragments did work, use the best alignment.
       if [[ $MafftTestingStrategy == "MinAlnLength" ]]; then
-        PenaltyForAddFrag=$("$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+        PenaltyForAddFrag=$($Python "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
         "$TempContigAlignment1" | awk '{print $2}') || { echo "Problem running"\
         "$Code_PrintSeqLengths." >&2 ; return 1 ; }
       elif [[ $MafftTestingStrategy == "MinMaxGappiness" ]]; then
-        PenaltyForAddFrag=$("$Code_ConstructRef" "$TempContigAlignment2" 'DummyOut' \
+        PenaltyForAddFrag=$($Python "$Code_ConstructRef" "$TempContigAlignment2" 'DummyOut' \
         $ContigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}') || { echo \
         "Problem analysing $TempContigAlignment2 (i.e. the output from aligning "\
         "$ContigFile and $ThisRefAlignment) with $Code_ConstructRef." \
@@ -139,9 +139,9 @@ function PrintAlnLengthIncrease {
   NewAln=$2
 
   # Print the increase in the alignment length as a result of adding the contigs
-  OldAlnLength=$("$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+  OldAlnLength=$($Python "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
   "$OldAln" | awk '{print $2}') &&
-  NewAlnLength=$("$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+  NewAlnLength=$($Python "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
   "$NewAln" | awk '{print $2}') ||
   { echo "Problem running $Code_PrintSeqLengths." >&2 ; return 1 ; }
   AlnLengthIncrease=$((NewAlnLength - OldAlnLength))
@@ -507,7 +507,7 @@ function ProcessBam {
   "$PileupFile" || { echo 'Failed to generate pileup.' >&2 ; return 1 ; }
 
   # Generate the base frequencies
-  "$Code_AnalysePileup" "$PileupFile" "$LocalRef" > "$BaseFreqs" || \
+  $Python "$Code_AnalysePileup" "$PileupFile" "$LocalRef" > "$BaseFreqs" || \
   { echo 'Problem analysing the pileup.' >&2 ; return 1 ; }
 
   # Generate a version of the base freqs file with HXB2 coordinates, if desired.
@@ -534,14 +534,14 @@ function ProcessBam {
 
       "$mafft" $MafftArgsForPairwise "$RefWHXB2unaln" > "$RefWHXB2aln" ||
       { echo "Problem running $mafft $MafftArgsForPairwise" >&2 ; return 1 ; }
-      "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" --pairwise-aln \
+      $Python "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" --pairwise-aln \
       "$RefWHXB2aln" > "$BaseFreqsWHXB2" ||
       { echo "Problem running $Code_MergeBaseFreqsAndCoords" >&2 ; return 1 ; }
     fi
   fi
 
   # Call the consensuses
-  "$Code_CallConsensus" "$BaseFreqs" "$MinCov1" "$MinCov2" "$MinBaseFrac" \
+  $Python "$Code_CallConsensus" "$BaseFreqs" "$MinCov1" "$MinCov2" "$MinBaseFrac" \
   --consensus-seq-name "$OutFileStem"'_consensus' --ref-seq-name "$LocalRefName" > \
   "$Consensus" || \
   { echo 'Problem calling the consensus.' >&2 ; return 1 ; }
@@ -654,7 +654,7 @@ function GetHIVcontigs {
   fi
 
   # Create a new file of contigs keeping only those that are long enough.
-  "$Code_FindSeqsInFasta" "$ContigFile" -N "" --match-start --min-length \
+  $Python "$Code_FindSeqsInFasta" "$ContigFile" -N "" --match-start --min-length \
   "$MinContigLength" > "$LongContigs" || { echo "Problem removing short"\
   "contigs from $ContigFile." >&2 ; return 1 ; }
 
@@ -690,7 +690,7 @@ function GetHIVcontigs {
 
   # Extract those contigs that have a blast hit.
   awk -F, '{print $1}' "$BlastFile" | sort | uniq > "$HIVContigsListOrig"
-  "$Code_FindSeqsInFasta" "$LongContigs" -F "$HIVContigsListOrig" > \
+  $Python "$Code_FindSeqsInFasta" "$LongContigs" -F "$HIVContigsListOrig" > \
   "$HIVcontigsFile" || { echo 'Problem extracting the HIV contigs using the'\
   'blast results.' >&2 ; return 1 ; }
 

--- a/shiver_init.sh
+++ b/shiver_init.sh
@@ -64,14 +64,14 @@ database="$OutDir"/'ExistingRefsBlastDatabase'
 
 # Copy the three input fasta files into the initialisation directory, removing
 # pure-gap columns from RefAlignment.
-"$Code_RemoveBlankCols" "$RefAlignment" > "$NewRefAlignment" || \
+$Python "$Code_RemoveBlankCols" "$RefAlignment" > "$NewRefAlignment" || \
 { echo "Problem removing pure-gap columns from $RefAlignment. Quitting." >&2 ; \
 exit 1; }
 cp "$adapters" "$OutDir"/'adapters.fasta'
 cp "$primers" "$OutDir"/'primers.fasta'
 
 if [[ "$TrimPrimerWithOneSNP" == "true" ]]; then
-  "$Code_AddSNPsToSeqs" "$OutDir/primers.fasta" \
+  $Python "$Code_AddSNPsToSeqs" "$OutDir/primers.fasta" \
   "$OutDir/PrimersWithSNPs.fasta" || { echo "Problem generating all possible"\
   "variants of the sequences in $primers differing by a single base mutation."\
   "Quitting." >&2; exit 1; }
@@ -100,7 +100,7 @@ if [[ "$RefNames" == *","* ]]; then
 fi
 
 # Ungap RefAlignment
-"$Code_UngapFasta" "$NewRefAlignment" > "$UngappedRefs" || \
+$Python "$Code_UngapFasta" "$NewRefAlignment" > "$UngappedRefs" || \
 { echo "Problem ungapping $RefAlignment. Quitting." >&2 ; exit 1; }
 
 # Create the blast database
@@ -115,5 +115,5 @@ IndividualRefDir="$OutDir"/'IndividualRefs'
 mkdir -p "$IndividualRefDir" || \
 { echo "Problem making the directory $IndividualRefDir. Quitting." >&2 ; \
 exit 1; }
-"$Code_SplitFasta" -G "$RefAlignment" "$IndividualRefDir" || { echo "Problem" \
+$Python "$Code_SplitFasta" -G "$RefAlignment" "$IndividualRefDir" || { echo "Problem" \
 "splitting $RefAlignment into one file per sequence. Quitting." >&2 ; exit 1; }

--- a/tools/AddAllPossibleSNPsToSeqs.py
+++ b/tools/AddAllPossibleSNPsToSeqs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/AnalysePileup.py
+++ b/tools/AnalysePileup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/CallConsensus.py
+++ b/tools/CallConsensus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/CheckFastaFileEquality.py
+++ b/tools/CheckFastaFileEquality.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/ConstructBestRef.py
+++ b/tools/ConstructBestRef.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/CorrectContigs.py
+++ b/tools/CorrectContigs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk and Francois Blanquart who

--- a/tools/CutAlignedContigs.py
+++ b/tools/CutAlignedContigs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Tanya Golubchik and Chris Wymant chris.wymant@bdi.ox.ac.uk

--- a/tools/FillConsensusGaps.py
+++ b/tools/FillConsensusGaps.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/FindContaminantReadPairs.py
+++ b/tools/FindContaminantReadPairs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/FindNamedReadsInSortedFastq.py
+++ b/tools/FindNamedReadsInSortedFastq.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/FindSeqsInFasta.py
+++ b/tools/FindSeqsInFasta.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/KeepBestLinesInDataFile.py
+++ b/tools/KeepBestLinesInDataFile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/MergeAlignments.py
+++ b/tools/MergeAlignments.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/MergeBaseFreqsAndCoords.py
+++ b/tools/MergeBaseFreqsAndCoords.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/PrintSeqLengths.py
+++ b/tools/PrintSeqLengths.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/RemoveBlankColumns.py
+++ b/tools/RemoveBlankColumns.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/SplitFasta.py
+++ b/tools/SplitFasta.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk

--- a/tools/UngapFasta.py
+++ b/tools/UngapFasta.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk


### PR DESCRIPTION
Hi Chris

To help a bit with maintaining shiver (and I also I don t want to replace python with python2 in the shebangs every time I git pull), I propose the following:

1. rm the shebangs
2. replace them with explicit python calls in the shell scripts
3. add $Python to config.sh, e.g. in the config.sh that comes with shiver, there is now a line Python='/usr/bin/env python2'
4. This in this pull request, I modified the original code to e.g.

# Find the read pairs that blast best to something other than the reference.
    $Python "$Code_FindContaminantReadPairs" "$reads1blast2" "$reads2blast2" \
    "$RefName" "$BadReadsBaseName" && ls "$BadReadsBaseName"_1.txt \
    "$BadReadsBaseName"_2.txt > /dev/null 2>&1 || \
    { echo 'Problem finding contaminant read pairs using' \
    "$Code_FindContaminantReadPairs. Quitting." >&2 ; exit 1 ; }

I have done this for all the python functions in "shiver_funcs.sh", and tested that the MysteryHIV example still runs ok.

Hope this helps,

olli

