### PR TITLE
Updated to use python3 and simplified installation of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ If you use shiver, please also cite its dependencies. Citation details [here](in
 
 shiver runs natively on Linux and Mac OS, but not Windows.
 However on any operating system (including Windows), if you have [VirtualBox](https://www.virtualbox.org/wiki/Downloads) installed, you can run [this](https://www.dropbox.com/sh/j3pmmunhxlc7g1w/AABddPfc5dN9oVnP9vQfAZOta?dl=0) image of Ubuntu Linux 16.04.3 which contains shiver, our separate tool [phyloscanner](https://github.com/BDI-pathogens/phyloscanner) (which allows you to investigate the within- and between-host diversity in mapped reads produced e.g. by shiver), all of their dependencies, and also the assembler [SPAdes](http://cab.spbu.ru/software/spades/) which can be used to assemble contigs suitable as input for shiver.  
-shiver dependencies: [Fastaq](https://github.com/sanger-pathogens/Fastaq), [samtools](http://www.htslib.org/), [biopython](http://biopython.org/wiki/Download), [mafft](http://mafft.cbrc.jp/alignment/software/), [blast](https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download) version 2.2.28 or higher (warning: earlier versions of blast have a bug that prevents shiver from correcting contigs), [trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic) (optional: needed if you want to trim reads for quality or adapter sequences) and at least one of [smalt](http://www.sanger.ac.uk/science/tools/smalt-0) or [BWA](http://bio-bwa.sourceforge.net/) or [bowtie](http://bowtie-bio.sourceforge.net/index.shtml) for mapping.
-Installation instructions for all of these are [here](info/InstallationNotes.sh).  
 
+## dependencies
+shiver dependencies: [Fastaq](https://github.com/sanger-pathogens/Fastaq), [samtools](http://www.htslib.org/), [biopython](http://biopython.org/wiki/Download), [mafft](http://mafft.cbrc.jp/alignment/software/), [blast](https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download) version 2.2.28 or higher (warning: earlier versions of blast have a bug that prevents shiver from correcting contigs), [trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic) (optional: needed if you want to trim reads for quality or adapter sequences) and at least one of [smalt](http://www.sanger.ac.uk/science/tools/smalt-0) or [BWA](http://bio-bwa.sourceforge.net/) or [bowtie](http://bowtie-bio.sourceforge.net/index.shtml) for mapping.
+Manual installation instructions for all of these dependencies are [here](info/InstallationNotes.sh). Otherwise, installation can be simplified using `conda`:
+
+```
+# install miniconda3: https://docs.conda.io/en/latest/miniconda.html
+# install mamba
+conda install mamba -n base -c conda-forge
+
+# change to Shiver directory, e.g. cd ~/shiver, then make shiver environment
+mamba env create -f environment.yml
+
+#activate the environment
+mamba activate shiver
+```
+
+## manual
 The shiver manual is [here](info/ShiverManual.pdf).

--- a/config.sh
+++ b/config.sh
@@ -15,7 +15,7 @@ MinContigHitFrac=0.9
 # What do you have to type into the command line to make these commands execute?
 # (If the binary file lives in a directory that is not included in your $PATH
 # variable, you will need to include the path here.)
-python2='python2'
+python='python'
 BlastDBcommand='makeblastdb'
 BlastNcommand='blastn'
 smalt='smalt'

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: shiver
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - blast==2.13.0
+  - bowtie2==2.5.0
+  - bwa==0.7.17
+  - mafft==7.515
+  - picard==2.27.4
+  - pip==23.0
+  - samtools==1.16.1
+  - smalt==0.7.6
+  - trimmomatic==0.39
+  - pip:
+   - biopython==1.80
+   - pyfastaq==3.17.0

--- a/shiver_align_contigs.sh
+++ b/shiver_align_contigs.sh
@@ -92,7 +92,7 @@ PrintAlnLengthIncrease "$RefAlignment" "$RawContigAlignment" || \
 "contigs to the existing references. Quitting." >&2 ; exit 1 ; }
 
 # Run the contig cutting & flipping code
-"$python2" "$Code_CorrectContigs" "$BlastFile" "$ContigMinBlastOverlapToMerge" \
+"$python" "$Code_CorrectContigs" "$BlastFile" "$ContigMinBlastOverlapToMerge" \
 -C "$ContigFile" -O "$CutContigFile" -B "$MergedBlastFile" || \
 { echo "Problem encountered running $Code_CorrectContigs. Quitting." >&2 ; \
 exit 1; }
@@ -117,7 +117,7 @@ if [[ -f "$CutContigFile" ]]; then
 
   # Split gappy contigs after alignment.
   CutContigNames=$(awk '/^>/ {print substr($1,2)}' "$CutContigFile")
-  "$python2" "$Code_CutAlignedContigs" "$TempContigAlignment3" $CutContigNames \
+  "$python" "$Code_CutAlignedContigs" "$TempContigAlignment3" $CutContigNames \
   $CutAlignedContigsArgs > "$CutContigAlignment"
   CutAlignedContigsStatus=$?
   if [[ $CutAlignedContigsStatus == 3 ]]; then
@@ -138,7 +138,7 @@ else
   # want to split the aligned raw contigs. If so, name it the same as aligned
   # cut contigs for consistency.
   RawContigNames=$(awk '/^>/ {print substr($1,2)}' "$RawContigFile1")
-  "$python2" "$Code_CutAlignedContigs" "$RawContigAlignment" $RawContigNames \
+  "$python" "$Code_CutAlignedContigs" "$RawContigAlignment" $RawContigNames \
   $CutAlignedContigsArgs > "$CutContigAlignment"
   CutAlignedContigsStatus=$?
   if [[ $CutAlignedContigsStatus == 3 ]]; then
@@ -150,7 +150,7 @@ else
     exit 1
   fi
 
-  equal=$("$python2" "$Code_CheckFastaFileEquality" "$RawContigAlignment" \
+  equal=$("$python" "$Code_CheckFastaFileEquality" "$RawContigAlignment" \
   "$CutContigAlignment") || { echo "Problem running"\
   "$Code_CheckFastaFileEquality. Quitting." >&2 ; exit 1 ; }
   if [[ "$equal" == "true" ]]; then

--- a/shiver_full_auto.sh
+++ b/shiver_full_auto.sh
@@ -61,7 +61,7 @@ HIVcontigNames=$(awk '/^>/ {print substr($1,2)}' "$RawContigFile1")
 
 # Run the contig cutting & flipping code. Check it works, and quit if it thinks
 # the contigs need correcting.
-"$python2" "$Code_CorrectContigs" "$BlastFile" --min-hit-frac "$MinContigHitFrac" || \
+"$python" "$Code_CorrectContigs" "$BlastFile" --min-hit-frac "$MinContigHitFrac" || \
 { echo "The contigs in $ContigFile appear to need correcting (or a problem" \
 "was encountered running $Code_CorrectContigs; check any error messages" \
 "above). Fully automatic processing not possible. Quitting." >&2 ; exit 1 ; }
@@ -93,7 +93,7 @@ for ref in "$InitDir"/'IndividualRefs'/*'.fasta'; do
     echo "Error: unexpected whitespace in file $AlnFile1. Quitting." >&2
     exit 1
   fi
-  RefSimilarityScore1=$("$python2" "$Code_ConstructRef" "$AlnFile1" 'DummyOut' \
+  RefSimilarityScore1=$("$python" "$Code_ConstructRef" "$AlnFile1" 'DummyOut' \
   $HIVcontigNames --print-best-score | awk '{print $1}')
   echo $RefSimilarityScore1 "$AlnFile1" >> "$RefMatchLog"
 
@@ -110,7 +110,7 @@ for ref in "$InitDir"/'IndividualRefs'/*'.fasta'; do
   OldMafft=true
   rm "$AlnFile2"
   continue ; }
-  RefSimilarityScore2=$("$python2" "$Code_ConstructRef" "$AlnFile2" 'DummyOut' \
+  RefSimilarityScore2=$("$python" "$Code_ConstructRef" "$AlnFile2" 'DummyOut' \
   $HIVcontigNames --print-best-score | awk '{print $1}')
   echo $RefSimilarityScore2 "$AlnFile2" >> "$RefMatchLog"
 
@@ -123,7 +123,7 @@ mv "$BestRefFile" "$BestContigToRefAlignment"
 
 # Check that the gappiest contig is not too gappy in the best contig-to-ref
 # alignment.
-LargestGapFrac=$("$python2" "$Code_ConstructRef" "$BestContigToRefAlignment" 'DummyOut' \
+LargestGapFrac=$("$python" "$Code_ConstructRef" "$BestContigToRefAlignment" 'DummyOut' \
 $HIVcontigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}')
 if (( $(echo "$LargestGapFrac > $MaxContigGappiness" | bc -l) )); then
   echo "The gappiest contig in the best contig-to-reference alignment," \
@@ -134,7 +134,7 @@ if (( $(echo "$LargestGapFrac > $MaxContigGappiness" | bc -l) )); then
 fi
 
 # Extract a gapless form of the best ref from its alignment to the contigs.
-#"$python2" "$Code_FindSeqsInFasta" "$BestContigToRefAlignment" $HIVcontigNames -v -g > \
+#"$python" "$Code_FindSeqsInFasta" "$BestContigToRefAlignment" $HIVcontigNames -v -g > \
 #"$TheRef" || \
 #{ echo "Problem extracting the ref from $BestRefFile. Quitting." >&2; exit 1 ; }
 #NumSeqs=$(grep -e '^>' "$TheRef" | wc -l)
@@ -145,7 +145,7 @@ fi
 #fi
 
 # Construct the tailored ref
-"$python2" "$Code_ConstructRef" "$BestContigToRefAlignment" "$GappyRefWithExtraSeq" \
+"$python" "$Code_ConstructRef" "$BestContigToRefAlignment" "$GappyRefWithExtraSeq" \
 $HIVcontigNames ||
 { echo 'Failed to construct a ref from the alignment. Quitting.' >&2; exit 1 ; }
 
@@ -153,7 +153,7 @@ $HIVcontigNames ||
 awk '/^>/{if(N)exit;++N;} {print;}' "$GappyRefWithExtraSeq" > "$RefWithGaps"
 
 # Remove any gaps from the reference
-"$python2" "$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
+"$python" "$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
 { echo 'Gap stripping code failed. Quitting.' >&2 ; exit 1 ; }
 
 # Map!

--- a/shiver_funcs.sh
+++ b/shiver_funcs.sh
@@ -53,7 +53,7 @@ function AlignContigsToRefs {
     "$TempContigAlignment1" || \
     { echo "Problem aligning $ContigFile using $mafft." >&2 ; return 1 ; }
   elif [[ "$Aligner" == "$Code_AlignToConsensus" ]]; then
-    "$python2" "$Aligner" $AlignerOptions --add "$ContigFile" \
+    "$python" "$Aligner" $AlignerOptions --add "$ContigFile" \
     "$ThisRefAlignment" > "$TempContigAlignment1" || \
     { echo "Problem aligning $ContigFile using $Code_AlignToConsensus." >&2 ; return 1 ; }
   else
@@ -63,11 +63,11 @@ function AlignContigsToRefs {
   fi
 
   if [[ $MafftTestingStrategy == "MinAlnLength" ]]; then
-    PenaltyForAdd=$("$python2" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+    PenaltyForAdd=$("$python" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
     "$TempContigAlignment1" | awk '{print $2}') || { echo "Problem running"\
     "$Code_PrintSeqLengths." >&2 ; return 1 ; }
   elif [[ $MafftTestingStrategy == "MinMaxGappiness" ]]; then
-    PenaltyForAdd=$("$python2" "$Code_ConstructRef" "$TempContigAlignment1" 'DummyOut' \
+    PenaltyForAdd=$("$python" "$Code_ConstructRef" "$TempContigAlignment1" 'DummyOut' \
     $ContigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}') || { echo 'Problem'\
     "analysing $TempContigAlignment1 (i.e. the output from aligning $ContigFile"\
     "and $ThisRefAlignment) with $Code_ConstructRef." >&2 ; return 1 ; }
@@ -90,11 +90,11 @@ function AlignContigsToRefs {
 
       # ...however if addfragments did work, use the best alignment.
       if [[ $MafftTestingStrategy == "MinAlnLength" ]]; then
-        PenaltyForAddFrag=$("$python2" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+        PenaltyForAddFrag=$("$python" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
         "$TempContigAlignment1" | awk '{print $2}') || { echo "Problem running"\
         "$Code_PrintSeqLengths." >&2 ; return 1 ; }
       elif [[ $MafftTestingStrategy == "MinMaxGappiness" ]]; then
-        PenaltyForAddFrag=$("$python2" "$Code_ConstructRef" "$TempContigAlignment2" 'DummyOut' \
+        PenaltyForAddFrag=$("$python" "$Code_ConstructRef" "$TempContigAlignment2" 'DummyOut' \
         $ContigNames --summarise-contigs-1 | sort -nrk2,2 | head -1 | awk '{print $2}') || { echo \
         "Problem analysing $TempContigAlignment2 (i.e. the output from aligning "\
         "$ContigFile and $ThisRefAlignment) with $Code_ConstructRef." \
@@ -152,9 +152,9 @@ function PrintAlnLengthIncrease {
   NewAln=$2
 
   # Print the increase in the alignment length as a result of adding the contigs
-  OldAlnLength=$("$python2" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+  OldAlnLength=$("$python" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
   "$OldAln" | awk '{print $2}') &&
-  NewAlnLength=$("$python2" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
+  NewAlnLength=$("$python" "$Code_PrintSeqLengths" --first-seq-only --include-gaps \
   "$NewAln" | awk '{print $2}') ||
   { echo "Problem running $Code_PrintSeqLengths." >&2 ; return 1 ; }
   AlnLengthIncrease=$((NewAlnLength - OldAlnLength))
@@ -520,7 +520,7 @@ function ProcessBam {
   "$PileupFile" || { echo 'Failed to generate pileup.' >&2 ; return 1 ; }
 
   # Generate the base frequencies
-  "$python2" "$Code_AnalysePileup" "$PileupFile" "$LocalRef" > "$BaseFreqs" || \
+  "$python" "$Code_AnalysePileup" "$PileupFile" "$LocalRef" > "$BaseFreqs" || \
   { echo 'Problem analysing the pileup.' >&2 ; return 1 ; }
 
   # Generate a version of the base freqs file with HXB2 coordinates, if desired.
@@ -547,14 +547,14 @@ function ProcessBam {
 
       "$mafft" $MafftArgsForPairwise "$RefWHXB2unaln" > "$RefWHXB2aln" ||
       { echo "Problem running $mafft $MafftArgsForPairwise" >&2 ; return 1 ; }
-      "$python2" "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" --pairwise-aln \
+      "$python" "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" --pairwise-aln \
       "$RefWHXB2aln" > "$BaseFreqsWHXB2" ||
       { echo "Problem running $Code_MergeBaseFreqsAndCoords" >&2 ; return 1 ; }
     fi
   fi
 
   # Call the consensuses
-  "$python2" "$Code_CallConsensus" "$BaseFreqs" "$MinCov1" "$MinCov2" "$MinBaseFrac" \
+  "$python" "$Code_CallConsensus" "$BaseFreqs" "$MinCov1" "$MinCov2" "$MinBaseFrac" \
   --consensus-seq-name "$OutFileStem"'_consensus' --ref-seq-name "$LocalRefName" > \
   "$Consensus" || \
   { echo 'Problem calling the consensus.' >&2 ; return 1 ; }
@@ -667,7 +667,7 @@ function GetHIVcontigs {
   fi
 
   # Create a new file of contigs keeping only those that are long enough.
-  "$python2" "$Code_FindSeqsInFasta" "$ContigFile" -N "" --match-start --min-length \
+  "$python" "$Code_FindSeqsInFasta" "$ContigFile" -N "" --match-start --min-length \
   "$MinContigLength" > "$LongContigs" || { echo "Problem removing short"\
   "contigs from $ContigFile." >&2 ; return 1 ; }
 
@@ -703,7 +703,7 @@ function GetHIVcontigs {
 
   # Extract those contigs that have a blast hit.
   awk -F, '{print $1}' "$BlastFile" | sort | uniq > "$HIVContigsListOrig"
-  "$python2" "$Code_FindSeqsInFasta" "$LongContigs" -F "$HIVContigsListOrig" > \
+  "$python" "$Code_FindSeqsInFasta" "$LongContigs" -F "$HIVContigsListOrig" > \
   "$HIVcontigsFile" || { echo 'Problem extracting the HIV contigs using the'\
   'blast results.' >&2 ; return 1 ; }
 

--- a/shiver_init.sh
+++ b/shiver_init.sh
@@ -64,14 +64,14 @@ database="$OutDir"/'ExistingRefsBlastDatabase'
 
 # Copy the three input fasta files into the initialisation directory, removing
 # pure-gap columns from RefAlignment.
-"$python2" "$Code_RemoveBlankCols" "$RefAlignment" > "$NewRefAlignment" || \
+"$python" "$Code_RemoveBlankCols" "$RefAlignment" > "$NewRefAlignment" || \
 { echo "Problem removing pure-gap columns from $RefAlignment. Quitting." >&2 ; \
 exit 1; }
 cp "$adapters" "$OutDir"/'adapters.fasta'
 cp "$primers" "$OutDir"/'primers.fasta'
 
 if [[ "$TrimPrimerWithOneSNP" == "true" ]]; then
-  "$python2" "$Code_AddSNPsToSeqs" "$OutDir/primers.fasta" \
+  "$python" "$Code_AddSNPsToSeqs" "$OutDir/primers.fasta" \
   "$OutDir/PrimersWithSNPs.fasta" || { echo "Problem generating all possible"\
   "variants of the sequences in $primers differing by a single base mutation."\
   "Quitting." >&2; exit 1; }
@@ -100,7 +100,7 @@ if [[ "$RefNames" == *","* ]]; then
 fi
 
 # Ungap RefAlignment
-"$python2" "$Code_UngapFasta" "$NewRefAlignment" > "$UngappedRefs" || \
+"$python" "$Code_UngapFasta" "$NewRefAlignment" > "$UngappedRefs" || \
 { echo "Problem ungapping $RefAlignment. Quitting." >&2 ; exit 1; }
 
 # Create the blast database
@@ -115,5 +115,5 @@ IndividualRefDir="$OutDir"/'IndividualRefs'
 mkdir -p "$IndividualRefDir" || \
 { echo "Problem making the directory $IndividualRefDir. Quitting." >&2 ; \
 exit 1; }
-"$python2" "$Code_SplitFasta" -G "$RefAlignment" "$IndividualRefDir" || { echo "Problem" \
+"$python" "$Code_SplitFasta" -G "$RefAlignment" "$IndividualRefDir" || { echo "Problem" \
 "splitting $RefAlignment into one file per sequence. Quitting." >&2 ; exit 1; }

--- a/shiver_map_reads.sh
+++ b/shiver_map_reads.sh
@@ -68,7 +68,7 @@ if [[ "$TrimPrimerWithOneSNP" == "true" ]]; then
     "in the config file was set to false when you ran shiver_init.sh, and you"\
     "changed it to true afterwards? You can generate this file from your"\
     "primers by running" >&2
-    echo "$python2" "$Code_AddSNPsToSeqs $InitDir/primers.fasta"\
+    echo "$python" "$Code_AddSNPsToSeqs $InitDir/primers.fasta"\
     "$InitDir/PrimersWithSNPs.fasta" >&2
     echo "(Though be careful copying and pasting that if any file paths"\
     "contain whitespace.) Quitting." >&2
@@ -124,7 +124,7 @@ elif [ "$NumSeqsInFastaFile" -eq 1 ]; then
 
   # Try to find the sequence in FastaFile in ExistingRefAlignment.
   RefName=$(awk '/^>/ {print substr($1,2)}' "$FastaFile")
-  "$python2" "$Code_FindSeqsInFasta" "$ExistingRefAlignment" -g -N "$RefName" > \
+  "$python" "$Code_FindSeqsInFasta" "$ExistingRefAlignment" -g -N "$RefName" > \
   "$RefFromAlignment" || \
   { echo "Could not find seq $RefName in $ExistingRefAlignment; that's OK," \
   'but after mapping we will not be able to produce a version of the' \
@@ -133,7 +133,7 @@ elif [ "$NumSeqsInFastaFile" -eq 1 ]; then
 
   # Compare the sequence in FastaFile to the one in ExistingRefAlignment.
   if $RefIsInAlignment; then
-    equal=$("$python2" "$Code_CheckFastaFileEquality" "$RefFromAlignment" "$FastaFile") ||
+    equal=$("$python" "$Code_CheckFastaFileEquality" "$RefFromAlignment" "$FastaFile") ||
     { echo 'Problem running' "$Code_CheckFastaFileEquality"'. Quitting.' >&2 ; \
     exit 1 ; }
     if [[ "$equal" == "false" ]]; then
@@ -159,7 +159,7 @@ elif [ "$NumSeqsInFastaFile" -eq 1 ]; then
   # Extract those contigs that have a blast hit.
   NumHIVContigsOrig=$(wc -w "$HIVContigsListOrig" | awk '{print $1}')
   if [[ $NumHIVContigsOrig -gt 0 ]]; then
-    "$python2" "$Code_FindSeqsInFasta" "$RawContigsFile" -F "$HIVContigsListOrig" > \
+    "$python" "$Code_FindSeqsInFasta" "$RawContigsFile" -F "$HIVContigsListOrig" > \
     "$RawContigFile2" || \
     { echo 'Problem extracting the HIV contigs. Quitting.' >&2 ; exit 1 ; }
   fi
@@ -190,16 +190,16 @@ else
   # ContigToRefAlignment, and check that they are the same as in
   # ExistingRefAlignment. Also extract just the contigs, stripping gaps, ready
   # for later.
-  "$python2" "$Code_FindSeqsInFasta" "$ContigToRefAlignment" -F "$HIVContigsListUser" -v > \
+  "$python" "$Code_FindSeqsInFasta" "$ContigToRefAlignment" -F "$HIVContigsListUser" -v > \
   "$TempRefAlignment" &&
-  "$python2" "$Code_FindSeqsInFasta" "$ContigToRefAlignment" -F "$HIVContigsListUser" -g > \
+  "$python" "$Code_FindSeqsInFasta" "$ContigToRefAlignment" -F "$HIVContigsListUser" -g > \
   "$RawContigFile2" || { echo 'Problem separating the contigs and existing'\
   "refs in $ContigToRefAlignment. Quitting." >&2 ; exit 1 ; }
-  "$python2" "$Code_RemoveBlankCols" "$TempRefAlignment" > "$AlignmentForTesting" || \
+  "$python" "$Code_RemoveBlankCols" "$TempRefAlignment" > "$AlignmentForTesting" || \
   { echo "Problem removing pure-gap columns from $TempRefAlignment (which was"\
   "created by removing the contigs from $ContigToRefAlignment - that's"\
   "probably the problematic file). Quitting." >&2 ; exit 1; }
-  equal=$("$python2" "$Code_CheckFastaFileEquality" "$AlignmentForTesting" \
+  equal=$("$python" "$Code_CheckFastaFileEquality" "$AlignmentForTesting" \
   "$ExistingRefAlignment") || { echo "Problem running"\
   "$Code_CheckFastaFileEquality. Quitting." >&2 ; exit 1 ; }
   if [[ "$equal" == "false" ]]; then
@@ -216,7 +216,7 @@ else
 
   # Construct the tailored ref
   HIVcontigNames=$(cat "$HIVContigsListUser")
-  "$python2" "$Code_ConstructRef" "$ContigToRefAlignment" "$GappyRefWithExtraSeq" \
+  "$python" "$Code_ConstructRef" "$ContigToRefAlignment" "$GappyRefWithExtraSeq" \
   $HIVcontigNames || \
   { echo 'Failed to construct a ref from the alignment. Quitting.' >&2 ; \
   exit 1 ; }
@@ -225,7 +225,7 @@ else
   awk '/^>/{if(N)exit;++N;} {print;}' "$GappyRefWithExtraSeq" > "$RefWithGaps"
 
   # Remove any gaps from the reference
-  "$python2" "$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
+  "$python" "$Code_UngapFasta" "$RefWithGaps" > "$TheRef" || \
   { echo 'Gap stripping code failed. Quitting.' >&2 ; exit 1 ; }
 
   RefName=$(awk '/^>/ {print substr($1,2)}' "$TheRef")
@@ -385,7 +385,7 @@ else
   # ...and now remove from these contigs those that are too short, leaving only
   # contaminants.
   if [ "$NumContaminantContigs" -gt 0 ]; then
-    "$python2" "$Code_FindSeqsInFasta" "$RawContigsFile" -F "$DiscardedContigNames" \
+    "$python" "$Code_FindSeqsInFasta" "$RawContigsFile" -F "$DiscardedContigNames" \
     --min-length "$MinContigLength" > "$RefAndContaminantContigs" ||
     { echo "Problem extracting contaminant contigs from $RawContigsFile." \
     "Quitting." >&2; exit 1; }
@@ -436,13 +436,13 @@ else
     # For multiple blast hits, keep the one with the highest evalue
     # TODO: test what blast does with fasta headers that have comments in them -
     # does it include them too?
-    "$python2" "$Code_KeepBestLinesInDataFile" "$reads1blast1" "$reads1blast2" &&
-    "$python2" "$Code_KeepBestLinesInDataFile" "$reads2blast1" "$reads2blast2" || 
+    "$python" "$Code_KeepBestLinesInDataFile" "$reads1blast1" "$reads1blast2" &&
+    "$python" "$Code_KeepBestLinesInDataFile" "$reads2blast1" "$reads2blast2" || 
     { echo "Problem extracting the best blast hits using"\
     "$Code_KeepBestLinesInDataFile. Quitting." >&2 ; exit 1 ; }
 
     # Find the read pairs that blast best to something other than the reference.
-    "$python2" "$Code_FindContaminantReadPairs" "$reads1blast2" "$reads2blast2" \
+    "$python" "$Code_FindContaminantReadPairs" "$reads1blast2" "$reads2blast2" \
     "$RefName" "$BadReadsBaseName" && ls "$BadReadsBaseName"_1.txt \
     "$BadReadsBaseName"_2.txt > /dev/null 2>&1 || \
     { echo 'Problem finding contaminant read pairs using' \
@@ -478,9 +478,9 @@ else
       fi
 
       # Extract the non-contaminant read pairs
-      "$python2" "$Code_FindReadsInFastq" -v -s "$reads1" "$BadReadsBaseName"_1.txt > \
+      "$python" "$Code_FindReadsInFastq" -v -s "$reads1" "$BadReadsBaseName"_1.txt > \
       "$cleaned1reads" &&
-      "$python2" "$Code_FindReadsInFastq" -v -s "$reads2" "$BadReadsBaseName"_2.txt > \
+      "$python" "$Code_FindReadsInFastq" -v -s "$reads2" "$BadReadsBaseName"_2.txt > \
       "$cleaned2reads" || \
       { echo 'Problem extracting the non-contaminant reads using' \
       "$Code_FindReadsInFastq"'. Quitting.' >&2 ; exit 1 ; }
@@ -492,9 +492,9 @@ else
       # Map the contaminant reads to the reference, to measure how useful the
       # cleaning procedure was.
       if [[ "$MapContaminantReads" == "true" ]]; then
-        "$python2" "$Code_FindReadsInFastq" -s "$reads1" "$BadReadsBaseName"_1.txt > \
+        "$python" "$Code_FindReadsInFastq" -s "$reads1" "$BadReadsBaseName"_1.txt > \
         "$BadReadsBaseName"_1.fastq &&
-        "$python2" "$Code_FindReadsInFastq" -s "$reads2" "$BadReadsBaseName"_2.txt > \
+        "$python" "$Code_FindReadsInFastq" -s "$reads2" "$BadReadsBaseName"_2.txt > \
         "$BadReadsBaseName"_2.fastq || \
         { echo 'Problem extracting the contaminant reads using' \
         "$Code_FindReadsInFastq. Quitting." >&2 ; exit 1 ; }
@@ -538,13 +538,13 @@ fi
 # Add gaps and excise unique insertions, to allow this consensus to be added to
 # a global alignment with others.
 if $RefIsInAlignment; then
-  "$python2" "$Code_MergeAlignments" "$GlobalAlignExcisionFlag" -L "$CoordsDict" \
+  "$python" "$Code_MergeAlignments" "$GlobalAlignExcisionFlag" -L "$CoordsDict" \
   "$TempRefAlignment" "$consensus" > "$ConsensusForGlobalAln" ||
   { echo 'Problem translating the coordinates of the consensus for the'\
   'global alignment. Quitting.' >&2 ; exit 1 ; }
 
   # Add the global alignment coordinates to the base frequencies file.
-  "$python2" "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" -C "$CoordsDict" > \
+  "$python" "$Code_MergeBaseFreqsAndCoords" "$BaseFreqs" -C "$CoordsDict" > \
   "$BaseFreqsWGlobal" || { echo 'Problem adding the global alignment'\
   'coordinates to the base frequencies file. Quitting.' >&2 ; exit 1 ; }
 
@@ -561,7 +561,7 @@ if [[ "$remap" == "true" ]]; then
 
   # Fill in any gaps in the consensus with the corresponding part of the orginal
   # reference for mapping.
-  "$python2" "$Code_FillConsensusGaps" "$consensus" '--output-seq-name' \
+  "$python" "$Code_FillConsensusGaps" "$consensus" '--output-seq-name' \
   "$NewRefName" > "$NewRef" || { echo 'Problem'\
   'filling in gaps in the consensus with the corresponding part of the orginal'\
   'reference for mapping. Quitting.' >&2 ; exit 1 ; }

--- a/tools/AddAllPossibleSNPsToSeqs.py
+++ b/tools/AddAllPossibleSNPsToSeqs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/AlignBaseFreqFiles_ByConsensuses.py
+++ b/tools/AlignBaseFreqFiles_ByConsensuses.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -153,7 +153,7 @@ def GetFreqs(BaseFreqsFile, consensus):
         continue
       fields = line.split(',')
       try:
-        freqs = map(int, fields[2:])
+        freqs = list(map(int, fields[2:]))
         assert len(freqs) == 6
       except (ValueError, AssertionError):
         print("Unexpected input format of", BaseFreqsFile + ". It appears that",
@@ -268,7 +268,7 @@ NumPosWithHigherCovIn1 = 0
 NumPosWithHigherCovIn2 = 0
 
 # Record each row of the csv file
-for PosMin1, (seq1freqs, seq2freqs) in enumerate(itertools.izip(AllSeq1freqs,
+for PosMin1, (seq1freqs, seq2freqs) in enumerate(zip(AllSeq1freqs,
 AllSeq2freqs)):
   PosInSeq1 = seq1PosConversions[PosMin1]
   PosInSeq2 = seq2PosConversions[PosMin1]
@@ -333,7 +333,7 @@ AllSeq2freqs)):
 # Print output
 if args.compare_snips_with_coverage:
   simple_total_diffs = 0
-  for PosMin1, (base1, base2) in enumerate(itertools.izip(seq1, seq2)):
+  for PosMin1, (base1, base2) in enumerate(zip(seq1, seq2)):
     if base1 != base2 and \
     PosMin1+1 >= args.start_pos_in_aln and \
     PosMin1+1 <= args.end_pos_in_aln and \

--- a/tools/AlignBaseFreqFiles_ByReference.py
+++ b/tools/AlignBaseFreqFiles_ByReference.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -157,7 +157,7 @@ def GetFreqs(BaseFreqsFile, RefSeq):
         ':', RefBase, 'in', BaseFreqsFile, 'but', GaplessRefSeq[RefPos-1],
         'in', args.alignment + '. Quitting.', file=sys.stderr)
         quit(1)
-      freqs = map(int, fields[2:])
+      freqs = list(map(int, fields[2:]))
       assert len(freqs) == 6
       FreqsInRef.append(freqs)
       LastRefPos += 1
@@ -217,7 +217,7 @@ NumPosWithHigherCovIn1 = 0
 NumPosWithHigherCovIn2 = 0
 
 # Record each row of the csv file
-for PosMin1, (ref1freqs, ref2freqs) in enumerate(itertools.izip(ref1freqs,
+for PosMin1, (ref1freqs, ref2freqs) in enumerate(zip(ref1freqs,
 ref2freqs)):
   PosInRef1 = ref1PosConversions[PosMin1]
   PosInRef2 = ref2PosConversions[PosMin1]

--- a/tools/AlignMoreSeqsToPairWithMissingCoverage.py
+++ b/tools/AlignMoreSeqsToPairWithMissingCoverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -94,7 +94,7 @@ if len(ConsensusAsString) != len(RefAsString):
   exit(1)
 NewConsensusAsString = ''
 NewRefAsString = ''
-for ConsensusBase, RefBase in itertools.izip(ConsensusAsString, RefAsString):
+for ConsensusBase, RefBase in zip(ConsensusAsString, RefAsString):
   if RefBase == '-' and (ConsensusBase == '-' or ConsensusBase == '?'):
     continue
   else:

--- a/tools/AnalysePileup.py
+++ b/tools/AnalysePileup.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -51,7 +51,7 @@ def ReadReferenceFromFile(File):
     print('Found', len(AllSequences), 'sequences in', ReferenceFile+\
     '; expected 1.\nQuitting.', file=sys.stderr)
     exit(1)
-  return AllSequences.items(), ReferenceLength
+  return list(AllSequences.items()), ReferenceLength
 
 # If a reference file was given, read it in; otherwise just check a directory
 # was specified.
@@ -102,7 +102,7 @@ IsInsertion, ReferenceLength):
       BaseCounts[ReferenceBase] = NumBasesMatchingReference
 
   # Warn about unexpected bases.
-  for base in BaseCounts.keys():
+  for base in list(BaseCounts.keys()):
     if not base in ExpectedBases:
       warning = 'WARNING: unexpected base '+base+' occurs '+\
       str(BaseCounts[base])+' times '
@@ -284,7 +284,7 @@ with open(PileupFile, 'r') as f:
     # Find the most common insertion size here.
     MostCommonInsertionSize = 0
     NumberOfReadsWithMostCommonInsertionSize = NumReadsWithoutInsertion
-    for InsertionSize,AllInsertionsThatSize in insertions.items():
+    for InsertionSize,AllInsertionsThatSize in list(insertions.items()):
       if len(AllInsertionsThatSize) > NumberOfReadsWithMostCommonInsertionSize:
         MostCommonInsertionSize = InsertionSize
         NumberOfReadsWithMostCommonInsertionSize = len(AllInsertionsThatSize)

--- a/tools/AuxiliaryFunctions.py
+++ b/tools/AuxiliaryFunctions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -33,7 +33,7 @@ acgt = ['A','C','G','T']
 ReverseIUPACdict = {}
 for UnambigLetter in acgt:
   ReverseIUPACdict[UnambigLetter] = [UnambigLetter]
-  for AmbigLetter,TargetLetters in IUPACdict.items():
+  for AmbigLetter,TargetLetters in list(IUPACdict.items()):
     if UnambigLetter in TargetLetters:
       ReverseIUPACdict[UnambigLetter].append(AmbigLetter)
 
@@ -60,13 +60,13 @@ def InterpretIUPAC(MyDict):
   for an ambiguity code key is divided equally between the letters involved in
   the ambiguity code.'''
 
-  keys = MyDict.keys()
+  keys = list(MyDict.keys())
   UpdatedDict = {}
   for UnambigLetter in acgt:
     if UnambigLetter in keys:
       UpdatedDict[UnambigLetter] = MyDict[UnambigLetter]
 
-  for AmbigLetter,TargetLetters in IUPACdict.items():
+  for AmbigLetter,TargetLetters in list(IUPACdict.items()):
     if AmbigLetter in keys:
       WeightPerTargetLetter = float(MyDict[AmbigLetter])/len(TargetLetters)
       for TargetLetter in TargetLetters:
@@ -115,7 +115,7 @@ def CallAmbigBaseIfNeeded(bases, coverage, MinCovForUpper, BaseFreqFile):
       except KeyError:
         print('Unexpected set of bases', bases, 'found in', BaseFreqFile, \
         ', not found amonst those for which we have ambiguity codes, namely:', \
-        ' '.join(ReverseIUPACdict2.keys()) + '. Quitting.', file=sys.stderr)
+        ' '.join(list(ReverseIUPACdict2.keys())) + '. Quitting.', file=sys.stderr)
         raise
   if coverage < MinCovForUpper - 0.5:
     return BaseHere.lower()
@@ -213,10 +213,10 @@ def ReadSequencesFromFile(DataFile,IsAlignment=True):
 
 
   # Check all sequences have the same length, if they're supposed to
-  FirstSequenceName, FirstSequence = AllSequences.items()[0]
+  FirstSequenceName, FirstSequence = list(AllSequences.items())[0]
   SequenceLength = len(FirstSequence)
   if IsAlignment:
-    for SequenceName, Sequence in AllSequences.items():
+    for SequenceName, Sequence in list(AllSequences.items()):
       if len(Sequence) != SequenceLength:
         print(SequenceName, 'has length', len(Sequence), 'whereas', \
         FirstSequenceName, 'has length', str(SequenceLength)+\

--- a/tools/CallConsensus.py
+++ b/tools/CallConsensus.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -126,7 +126,7 @@ def CallAmbigBaseIfNeeded(bases, coverage):
       except KeyError:
         print('Unexpected set of bases', bases, 'found in', BaseFreqFile, \
         ', not found amonst those for which we have ambiguity codes, namely:', \
-        ' '.join(ReverseIUPACdict2.keys()) + '. Quitting.', file=sys.stderr)
+        ' '.join(list(ReverseIUPACdict2.keys())) + '. Quitting.', file=sys.stderr)
         raise
   if coverage < MinCovForUpper - 0.5:
     return BaseHere.lower()
@@ -142,7 +142,7 @@ def CallEnoughBases(BaseCounts, MinCoverage, coverage):
   # Sort the counts from largest to smallest, and sort the associated bases into
   # a matching order.
   SortedBaseCounts, SortedExpectedBases = \
-  zip(*sorted(zip(BaseCounts, ExpectedBasesNoN), reverse=True))
+  list(zip(*sorted(zip(BaseCounts, ExpectedBasesNoN), reverse=True)))
 
   # Iterate through the counts, from largest to smallest, updating the total
   # so far. We should stop once we reach the desired total, but not if the next
@@ -203,7 +203,7 @@ with open(BaseFreqFile, 'r') as f:
 
     # Convert to ints    
     try:
-      counts = map(int, counts)
+      counts = list(map(int, counts))
     except ValueError:
       print('Could not understand the base counts as ints on line', \
       str(LineNumMin1+1), ',\n', line, 'in', BaseFreqFile + \
@@ -256,7 +256,7 @@ if not args.keep_gaps_by_missing:
 if not args.ref_seq_missing:
   NewConsensus = ''
   NewRefSeq = ''
-  for ConsensusBase, RefBase in itertools.izip(consensus, RefSeq):
+  for ConsensusBase, RefBase in zip(consensus, RefSeq):
     if RefBase == GapChar and (ConsensusBase == '?' or ConsensusBase == \
     GapChar):
       continue

--- a/tools/CallGlobalConsensusFromCsv.py
+++ b/tools/CallGlobalConsensusFromCsv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -75,7 +75,7 @@ with open(args.alignment_csv, 'r') as f:
     unprocessed_kmer_counts = Counter(unprocessed_kmers)
     kmer_counts = Counter()
     kmer_len_counts = Counter()
-    for unprocessed_kmer, count in unprocessed_kmer_counts.items():
+    for unprocessed_kmer, count in list(unprocessed_kmer_counts.items()):
       kmer = sub("[N-]+", "", unprocessed_kmer)
       len_kmer = len(kmer)
       if len_kmer > 0:

--- a/tools/CheckFastaFileEquality.py
+++ b/tools/CheckFastaFileEquality.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/CleanConsensuses.py
+++ b/tools/CleanConsensuses.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -218,10 +218,10 @@ with open(args.amplicon_regions_file, 'r') as f:
     regions_dict[region] = (start, end)
     regions_dict_not_empty = True
 last_region = next(reversed(regions_dict))
-first_region = regions_dict.keys()[0]
+first_region = list(regions_dict.keys())[0]
 last_start, last_end = regions_dict[last_region]
 first_start = regions_dict[first_region][0]
-regions = regions_dict.keys()
+regions = list(regions_dict.keys())
 num_regions = len(regions)
 
 # If we're splitting amplicons, set up file names for the per-region output
@@ -244,7 +244,7 @@ if args.split_amplicons:
   else:
     per_region_output_file_dict = {region : os.path.join(args.output,
     "region_" + region + ".fasta") for region in regions}
-  for output_file in per_region_output_file_dict.values():
+  for output_file in list(per_region_output_file_dict.values()):
     if os.path.isfile(output_file):
       print(output_file, "exists already; quitting to prevent overwriting.",
       file=sys.stderr)
@@ -448,7 +448,7 @@ for seq in collection_of_seqs:
       exit(1)
     regions_dict_this_aln = {}
     this_reference_by_region = {}
-    for region, region_boundaries in regions_dict.items():
+    for region, region_boundaries in list(regions_dict.items()):
       start_in_this_aln, end_in_this_aln = \
       TranslateSeqCoordsToAlnCoords(this_reference, region_boundaries)
       regions_dict_this_aln[region] = (start_in_this_aln, end_in_this_aln)
@@ -563,7 +563,7 @@ for seq in collection_of_seqs:
     # Add our own blacklisting of regions, based on the fraction that's not "N",
     # for regions that have not already been blacklisted.
     if not args.dont_blacklist_missingness:
-      for region_num in xrange(num_regions):
+      for region_num in range(num_regions):
         seq_in_blacklist = seq_id in seq_blacklist_dict
         if seq_in_blacklist and not seq_blacklist_dict[seq_id][region_num + 1]:
           continue
@@ -602,7 +602,7 @@ for seq in collection_of_seqs:
         ": discarding whole sequence as it was blacklisted.", sep='')
       continue
 
-    for region_num in xrange(num_regions):
+    for region_num in range(num_regions):
 
       # Mask blacklisted regions.
       keep_region = seq_blacklist_values[region_num + 1]
@@ -632,7 +632,7 @@ for seq in collection_of_seqs:
   if have_individual_consensus:
     seq_as_str = PropagateNoCoverageChar(seq_as_str)
     if args.split_amplicons:
-      for region, (start, end) in regions_dict_this_aln.items():
+      for region, (start, end) in list(regions_dict_this_aln.items()):
         region_length = end - start + 1
         seq_here = seq_as_str[start - 1: end].replace("-", "") # strip gaps
         seq_here = seq_here.strip("N") # strip Ns at the ends
@@ -720,9 +720,9 @@ if args.print_new_seq_blacklist != None:
 # region-specific files if desired. Nothing further for base freqs.
 if have_individual_consensus or have_base_freqs:
   if args.split_amplicons:
-    for region, output_file in per_region_output_file_dict.items():
+    for region, output_file in list(per_region_output_file_dict.items()):
       seq_dict_here = unaln_seqs_by_region[region]
-      sorted_seqs_here = sorted(seq_dict_here.items(), key=lambda x:x[0])
+      sorted_seqs_here = sorted(list(seq_dict_here.items()), key=lambda x:x[0])
       SeqIO.write((SeqIO.SeqRecord(Seq.Seq(seq), id=seq_id, description='') \
       for seq_id, seq in sorted_seqs_here), output_file, 'fasta')
   exit(0)
@@ -731,9 +731,9 @@ if have_individual_consensus or have_base_freqs:
 per_patient_seq_counts = \
 collections.Counter(get_beehive_id(seq_id) for seq_id in seq_dict)
 multiply_seqd_patients = set(patient for patient, count in \
-per_patient_seq_counts.items() if count > 1)
+list(per_patient_seq_counts.items()) if count > 1)
 singly_seqd_patients = set(patient for patient, count in \
-per_patient_seq_counts.items() if count == 1)
+list(per_patient_seq_counts.items()) if count == 1)
 seq_ids_for_multiply_seqd_patients = collections.defaultdict(list)
 for seq_id in seq_dict:
   beehive_id = get_beehive_id(seq_id)
@@ -743,18 +743,18 @@ for seq_id in seq_dict:
 
 # Merge multiple seqs per patient.
 for multiply_seqd_patient, seq_ids in \
-seq_ids_for_multiply_seqd_patients.items():
+list(seq_ids_for_multiply_seqd_patients.items()):
   seqs = [seq_dict[seq_id] for seq_id in seq_ids]
   num_seqs = len(seqs)
   seqs_by_length = sorted(seqs, key=lambda seq : alignment_length - \
   seq.count("N") - seq.count("-"), reverse=True)
   best_seq = ""
-  for pos in xrange(alignment_length):
+  for pos in range(alignment_length):
 
     # Try each seq in order from best to worst until one of them has something
     # other than an N:
     best_base = "N"
-    for i in xrange(num_seqs):
+    for i in range(num_seqs):
       base = seqs_by_length[i][pos]
       if base != "N":
         best_base = base
@@ -777,11 +777,11 @@ for seq_id in seq_dict:
   seq_dict[seq_id] = PropagateNoCoverageChar(seq_dict[seq_id])
 
 # Sort seqs by name
-sorted_seqs = sorted(seq_dict.items(), key=lambda x:x[0])
+sorted_seqs = sorted(list(seq_dict.items()), key=lambda x:x[0])
 
 if args.split_amplicons:
 
-  for region, (start, end) in regions_dict.items():
+  for region, (start, end) in list(regions_dict.items()):
     OutSeqs = []
     region_length = end - start + 1
     for seq_id, seq in sorted_seqs:

--- a/tools/CleanConsensusesNoAmplicons.py
+++ b/tools/CleanConsensusesNoAmplicons.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -197,12 +197,12 @@ if have_dates:
 
 # Iterate through patients and the set of seqs for each patient.
 final_seqs_dict = {}
-for beehive_id, sub_seq_dict in seq_dict.iteritems():
+for beehive_id, sub_seq_dict in seq_dict.items():
 
   # If this patient only has one sequence, nothing to do except restrict the 
   # seq id to the patient id and the date.
   if len(sub_seq_dict) == 1:
-    seq_id, seq_as_str = sub_seq_dict.items()[0]
+    seq_id, seq_as_str = list(sub_seq_dict.items())[0]
     seq_id_pieces = seq_id.split("_")
     seq_id_to_use = beehive_id + "_" + seq_id_pieces[1]
     assert not seq_id_to_use in final_seqs_dict
@@ -211,14 +211,14 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
 
   # Now we have multiple sequences for this patient. First, group them by date.
   seqs_by_date = collections.defaultdict(list)
-  for seq_id, seq_as_str in sub_seq_dict.iteritems():
+  for seq_id, seq_as_str in sub_seq_dict.items():
     date = seq_id.split("_", 2)[1]
     seqs_by_date[date].append(seq_as_str)
 
   # Merge multiple seqs from the same date: rank them by length, and at each
   # position use the base of the best seq that doesn't have an N there.
   merged_seqs_dict = {}
-  for date, seqs in seqs_by_date.iteritems():
+  for date, seqs in seqs_by_date.items():
     num_seqs = len(seqs)
     if num_seqs == 1:
       best_seq = seqs[0]
@@ -228,9 +228,9 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
       seqs_by_length = sorted(seqs, key=lambda seq : num_known_bases(seq),
       reverse=True)
       best_seq = ""
-      for pos in xrange(alignment_length):
+      for pos in range(alignment_length):
         best_base = "N"
-        for i in xrange(num_seqs):
+        for i in range(num_seqs):
           base = seqs_by_length[i][pos]
           if base != "N":
             best_base = base
@@ -240,7 +240,7 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
 
   # If we're including all dates for each pat, do so now...
   if not have_dates:
-    for date, seq in merged_seqs_dict.items():
+    for date, seq in list(merged_seqs_dict.items()):
       seq_id_to_use = beehive_id + "_" + date
       assert not seq_id_to_use in final_seqs_dict
       final_seqs_dict[seq_id_to_use] = seq
@@ -249,7 +249,7 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
 
   # If there is only one date, no choice:
   if len(merged_seqs_dict) == 1:
-    date, seq = merged_seqs_dict.items()[0]
+    date, seq = list(merged_seqs_dict.items())[0]
     seq_id_to_use = beehive_id + "_" + date
     assert not seq_id_to_use in final_seqs_dict
     final_seqs_dict[seq_id_to_use] = seq
@@ -263,7 +263,7 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
     pass
   else:
     if len(merged_seqs_dict) == 1:
-      date, seq = merged_seqs_dict.items()[0]
+      date, seq = list(merged_seqs_dict.items())[0]
       seq_id_to_use = beehive_id + "_" + date
       assert not seq_id_to_use in final_seqs_dict
       final_seqs_dict[seq_id_to_use] = seq
@@ -301,11 +301,11 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
     date_to_use = date_sampled
     if args.verbose:
       print("For", beehive_id, "with seq dates",
-      " and ".join(merged_seqs_dict.keys()) + ", using date", date_sampled,
+      " and ".join(list(merged_seqs_dict.keys())) + ", using date", date_sampled,
       "as this perfectly matches the Date.sampled in", args.date_sampled_csv)
   else:
     date_to_use = None
-    for seq_date in merged_seqs_dict.keys():
+    for seq_date in list(merged_seqs_dict.keys()):
       if date_to_use == None:
         seq_date_object = datetime.datetime.strptime(seq_date, '%Y-%m-%d')
         min_date_diff = abs((date_sampled_date_object - seq_date_object).days)
@@ -318,7 +318,7 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
           date_to_use = date
     if args.verbose:
       print("For", beehive_id, "with seq dates",
-      " and ".join(merged_seqs_dict.keys()) + ", using date", date_to_use,
+      " and ".join(list(merged_seqs_dict.keys())) + ", using date", date_to_use,
       "as this is the closest match to the Date.sampled -", date_sampled,
       "- in", args.date_sampled_csv)
 
@@ -329,11 +329,11 @@ for beehive_id, sub_seq_dict in seq_dict.iteritems():
   final_seqs_dict[seq_id_to_use] = seq_to_use
 
 # Iteratively replace gaps that border N by N.
-for seq_id, seq in final_seqs_dict.iteritems():
+for seq_id, seq in final_seqs_dict.items():
   final_seqs_dict[seq_id] = PropagateNoCoverageChar(seq)
 
 # Output the final seqs, sorted by name.
 sorted_seq_objects = [SeqIO.SeqRecord(Seq.Seq(seq), id=seq_id, description='') \
-for seq_id, seq in sorted(final_seqs_dict.items(), key=lambda x:x[0])]
+for seq_id, seq in sorted(list(final_seqs_dict.items()), key=lambda x:x[0])]
 SeqIO.write(sorted_seq_objects, args.output_file, 'fasta')
 

--- a/tools/CompareLengthsInPairwiseAln.py
+++ b/tools/CompareLengthsInPairwiseAln.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/CompareTwoNumMappedBasesFiles.py
+++ b/tools/CompareTwoNumMappedBasesFiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/ConstructBestRef.py
+++ b/tools/ConstructBestRef.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251 
@@ -213,7 +213,7 @@ ContigStartsAndEnds = {}
 ContigLengths = {}
 ContigGapFractions = {}
 TotalGapsInContigs = 0
-for ContigName,ContigSeq in ContigDict.items():
+for ContigName,ContigSeq in list(ContigDict.items()):
   StartOfContig, EndOfContig = FindSeqStartAndEnd(ContigName, ContigSeq, \
   AlignmentLength, AlignmentFile)
   ContigStartsAndEnds[ContigName] = [StartOfContig,EndOfContig]
@@ -225,7 +225,7 @@ for ContigName,ContigSeq in ContigDict.items():
   float(NumInternalGaps)/(EndOfContig+1 - StartOfContig)
 
 if args.summarise_contigs_1:
-  for ContigName, length in ContigLengths.items():
+  for ContigName, length in list(ContigLengths.items()):
     sys.stdout.write(str(length) + ' ' + str(ContigGapFractions[ContigName]))
   exit(0)
 
@@ -235,7 +235,7 @@ if args.summarise_contigs_1:
 
 AllContigStarts = []
 AllContigEnds = []
-for [ContigStart,ContigEnd] in ContigStartsAndEnds.values():
+for [ContigStart,ContigEnd] in list(ContigStartsAndEnds.values()):
   AllContigStarts.append(ContigStart)
   AllContigEnds.append(ContigEnd)
 StartOfFirstContig = min(AllContigStarts)
@@ -253,11 +253,11 @@ EndOfLastContig = max(AllContigEnds)
 FlattenedContigsSeq = GapChar * StartOfFirstContig
 for position in range(StartOfFirstContig,EndOfLastContig+1):
   DictOfBasesHere = {}
-  for ContigName,ContigSeq in ContigDict.items():
+  for ContigName,ContigSeq in list(ContigDict.items()):
     DictOfBasesHere[ContigName] = ContigSeq[position]
   BasesHere = set(DictOfBasesHere.values())
   if len(BasesHere) == 1:
-    BaseHere = DictOfBasesHere.values()[0]
+    BaseHere = list(DictOfBasesHere.values())[0]
   else:
     LengthOfLongestDesiredContig = 0
     for ContigName in DictOfBasesHere:
@@ -284,7 +284,7 @@ if args.contigs_length:
 # counting the number of contigs with coverage there. Gaps inside contigs get
 # counted as coverage; gaps between contigs get a count of 0.
 ContigCoverageByPosition = [0 for n in range(0,AlignmentLength)]
-for [start,end] in ContigStartsAndEnds.values():
+for [start,end] in list(ContigStartsAndEnds.values()):
   for position in range(start,end+1):
     ContigCoverageByPosition[position] += 1
 
@@ -306,7 +306,7 @@ if ConsensusName != None:
       if ContigCoverageByPosition[pos] < 2:
         continue
       ContigBases = []
-      for ContigName, ContigSeq in ContigDict.items():
+      for ContigName, ContigSeq in list(ContigDict.items()):
         StartOfContig, EndOfContig = ContigStartsAndEnds[ContigName]
         if StartOfContig <= pos <= EndOfContig:
           ContigBase = ContigSeq[pos]
@@ -338,7 +338,7 @@ if ConsensusName != None:
 
         # Find all bases (or gaps) inside a contig here.
         ContigBases = []
-        for ContigName, ContigSeq in ContigDict.items():
+        for ContigName, ContigSeq in list(ContigDict.items()):
           StartOfContig, EndOfContig = ContigStartsAndEnds[ContigName]
           if StartOfContig <= pos <= EndOfContig:
             ContigBases.append(ContigSeq[pos])
@@ -391,7 +391,7 @@ for position in range(0,AlignmentLength):
     LengthOfDeletions += 1
   if NumContigsHere == 1:
     NoRefHasBaseHere = True
-    for RefName,RefSeq in RefDict.items():
+    for RefName,RefSeq in list(RefDict.items()):
       if RefSeq[position] != GapChar:
         NoRefHasBaseHere = False
         break
@@ -410,7 +410,7 @@ if ExciseUniqueInsertions:
 # contig coverage where the two are in agreement. Record the reference start and
 # end.
 ListOfRefsAndScores = []
-for RefName,RefSeq in RefDict.items():
+for RefName,RefSeq in list(RefDict.items()):
   NumBasesAgreeing = 0
   OverlapLength = 0
   StartOfRef, EndOfRef = FindSeqStartAndEnd(RefName, RefSeq, AlignmentLength,
@@ -445,9 +445,9 @@ if args.print_best_score:
   exit(0)
 
 if args.summarise_contigs_2:
-  ContigsWithBestRef = [RefDict[BestRefName]] + ContigDict.values()
+  ContigsWithBestRef = [RefDict[BestRefName]] + list(ContigDict.values())
   NumSeqs = len(ContigsWithBestRef)
-  for column in xrange(AlignmentLength-1,-1,-1):
+  for column in range(AlignmentLength-1,-1,-1):
     if all(seq[column] == '-' for seq in ContigsWithBestRef):
       for i in range(NumSeqs):
         ContigsWithBestRef[i] = ContigsWithBestRef[i][:column] + \
@@ -498,7 +498,7 @@ for position in range(0,AlignmentLength):
 # Inserting line breaks: thanks Stackoverflow:
 def insert_newlines(string, every=50):
   lines = []
-  for i in xrange(0, len(string), every):
+  for i in range(0, len(string), every):
     lines.append(string[i:i+every])
   return '\n'.join(lines)
 

--- a/tools/ConvertAlnToColourCodes.py
+++ b/tools/ConvertAlnToColourCodes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/CorrectContigs.py
+++ b/tools/CorrectContigs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk and Francois Blanquart who
 ## wrote the original version of this script in R. Thanks to Tanya Golubchick
@@ -264,7 +264,7 @@ def MergeStronglyOverlappingHits(hits, MinOverlap):
   return hits
 
 CorrectionsNeeded = False
-for contig, hits in HitDict.items():
+for contig, hits in list(HitDict.items()):
 
   # Where a contig has one hit contained entirely inside another, remove the
   # sub-hit.
@@ -341,7 +341,7 @@ for contig, hits in HitDict.items():
 # Write the blast output if desired.
 if args.blast_output != None:
   with open(args.blast_output, "w") as f:
-    for contig, hits in HitDict.items():
+    for contig, hits in list(HitDict.items()):
       for hit in hits:
         f.write(",".join(map(str, hit)) + "\n")
 
@@ -360,7 +360,7 @@ for seq in SeqIO.parse(open(args.contigs),'fasta'):
   ContigDict[seq.id] = seq
 
 # Check we have a sequence for each hit
-UnknownHits = [hit for hit in HitDict.keys() if not hit in ContigDict.keys()]
+UnknownHits = [hit for hit in list(HitDict.keys()) if not hit in list(ContigDict.keys())]
 if len(UnknownHits) != 0:
   print('The following hits in', args.BlastFile, 'do not have a corresponding',\
   'sequence in', args.contigs +':\n', ' '.join(UnknownHits) + \
@@ -368,7 +368,7 @@ if len(UnknownHits) != 0:
   exit(1)
 
 OutSeqs = []
-for ContigName, hits in HitDict.items():
+for ContigName, hits in list(HitDict.items()):
 
   seq = ContigDict[ContigName]
   SeqLength = len(seq.seq)

--- a/tools/CutAlignedContigs.py
+++ b/tools/CutAlignedContigs.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Tanya Golubchik and Chris Wymant chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: written with funding from the ERC Advanced Grant PBDR-339251 
@@ -119,7 +119,7 @@ for seq in AlignedSeqs:
     NumRefSeqs += 1
 
 # Check if any of the named contigs were not found.
-MissingContigs = {contig for contig, found in ContigsFound.items() if not found}
+MissingContigs = {contig for contig, found in list(ContigsFound.items()) if not found}
 if MissingContigs:
   print("The following contigs were not found in " + args.alignment + ":",
   " ".join(MissingContigs) + '\nQuitting.', file=sys.stderr)

--- a/tools/EstimateAmbiguousBases.py
+++ b/tools/EstimateAmbiguousBases.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -44,11 +44,11 @@ OKbases = "ACGTNacgtn-?"
 
 BaseCountsByPos = []
 BaseCountTotalsByPos = []
-for pos in xrange(AlignmentLength):
+for pos in range(AlignmentLength):
 
   # Sort the OKbases here by how common they are. (Check there are some!)
   BaseCounts = collections.Counter(alignment[:, pos])
-  BasesObserved = BaseCounts.keys()
+  BasesObserved = list(BaseCounts.keys())
   for base in BasesObserved:
     if not base in OKbases:
       del BaseCounts[base]
@@ -64,10 +64,10 @@ for pos in xrange(AlignmentLength):
 MutableSeqList = [seq.seq.tomutable() for seq in alignment]
 IDs = [seq.id for seq in alignment]
 
-for row in xrange(len(MutableSeqList)):
+for row in range(len(MutableSeqList)):
   SeqAsStr = str(MutableSeqList[row])
   ID = IDs[row]
-  for pos in xrange(AlignmentLength):
+  for pos in range(AlignmentLength):
 
     # Check at this position whether ambiguity interpretation is needed.
     base = SeqAsStr[pos]

--- a/tools/ExactBLAST.py
+++ b/tools/ExactBLAST.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/FillConsensusGaps.py
+++ b/tools/FillConsensusGaps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -66,7 +66,7 @@ if len(ConsensusAsString) != len(RefAsString):
 # The main bit.
 NewConsensus = ''
 ExpectedBases = ['A', 'C', 'G', 'T', '-']
-for ConsensusBase, RefBase in itertools.izip(ConsensusAsString, RefAsString):
+for ConsensusBase, RefBase in zip(ConsensusAsString, RefAsString):
   if ConsensusBase == '?' or ConsensusBase == 'N':
     NewConsensus += RefBase
   elif ConsensusBase in ExpectedBases:

--- a/tools/FindAlignmentCoordFromSeqCoord.py
+++ b/tools/FindAlignmentCoordFromSeqCoord.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/FindClippingHotSpots.py
+++ b/tools/FindClippingHotSpots.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -98,14 +98,14 @@ if NumReads == 0:
 ClipPositionCounts = collections.Counter(ClipPositions)
 
 if args.min_read_count > 1:
-  ClipPositionCounts = {key:value for key, value in ClipPositionCounts.items() \
+  ClipPositionCounts = {key:value for key, value in list(ClipPositionCounts.items()) \
   if value >= args.min_read_count}
 
 # Print the output
 output = 'Reference position, Number of reads clipped, Percentage of spanning'+\
 ' reads clipped'
 
-for pos, count in sorted(ClipPositionCounts.items(), key=lambda x:x[1], \
+for pos, count in sorted(list(ClipPositionCounts.items()), key=lambda x:x[1], \
 reverse=True):
   # 100% of reads overhanging the start or end of the reference are clipped.
   if pos == 0 or pos == RefLength:

--- a/tools/FindContaminantReadPairs.py
+++ b/tools/FindContaminantReadPairs.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -83,7 +83,7 @@ HitsFor2reads = ReadBlastFile(BlastFileFor2reads)
 
 # Find contaminant read pairs
 ContaminantReadPairs = []
-for ReadName, [read1Hit, read1Evalue] in HitsFor1reads.items():
+for ReadName, [read1Hit, read1Evalue] in list(HitsFor1reads.items()):
 
   try:
     [read2Hit,read2Evalue] = HitsFor2reads[ReadName]

--- a/tools/FindNamedReadsInSortedFastq.py
+++ b/tools/FindNamedReadsInSortedFastq.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 #
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/FindNumMappedBases.py
+++ b/tools/FindNumMappedBases.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/FindSeqsInFasta.py
+++ b/tools/FindSeqsInFasta.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/FindSubSeqsInAlignment.py
+++ b/tools/FindSubSeqsInAlignment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251 
@@ -122,7 +122,7 @@ AllPrimersShorterThanRef = False
 for PositionMin1 in range(AlignmentLength-1,-1,-1):
   if not ChosenRefSeq[PositionMin1] in GapChars:
     NumRefBasesSoFar += 1
-    for primer,length in PrimerLengths.items():
+    for primer,length in list(PrimerLengths.items()):
       if NumRefBasesSoFar == length:
         PrimerLastChancesForMatch[primer] = PositionMin1+1
     if len(PrimerLastChancesForMatch) == NumUniquePrimers:
@@ -153,7 +153,7 @@ for PositionMin1,base in enumerate(ChosenRefSeq):
   # gaps in the reference.
   # When it equals the primer length, we have found that primer: we record the
   # primer position (start and/or end) in the alignment.
-  for primer,length in PrimerLengths.items():
+  for primer,length in list(PrimerLengths.items()):
     if PositionMin1 > PrimerLastChancesForMatch[primer]-1:
       continue
     matches = 0
@@ -186,8 +186,8 @@ if len(MissingPrimers) != 0:
 # Merge the start and end positions into a single sorted list, each value being
 # coupled to its primer name with 'start_of_' or 'end_of_' prepended.
 SortedList = [['start_of_'+primer,value] for primer,value in \
-StartPrimerPositions.items()] + [['end_of_'+primer,value] for primer,value in \
-EndPrimerPositions.items()]
+list(StartPrimerPositions.items())] + [['end_of_'+primer,value] for primer,value in \
+list(EndPrimerPositions.items())]
 SortedList = sorted(SortedList, key=lambda item: item[1])
 
 if args.AlignmentCoords:
@@ -200,7 +200,7 @@ if args.AlignmentCoords:
 # (ignoring gaps). Only count once through the genome, stopping and restarting
 # when we get to each primer.
 PositionsDict = {}
-for SeqName, seq in SeqDict.items():
+for SeqName, seq in list(SeqDict.items()):
   PositionsWRTseq = []
   LastPositionWRTalignment = 0
   PositionWRTseq = 0

--- a/tools/GetCoverageFromBamFile.py
+++ b/tools/GetCoverageFromBamFile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -62,5 +62,5 @@ for pos in range(min_ref_pos, max_ref_pos + 1):
     counts_by_ref_pos[pos] = 0
 
 print("reference position (1-based),coverage")
-for pos, coverage in sorted(counts_by_ref_pos.items(), key=lambda x:x[0]):
+for pos, coverage in sorted(list(counts_by_ref_pos.items()), key=lambda x:x[0]):
   print(pos + 1, coverage, sep=",")

--- a/tools/KeepBestLinesInDataFile.py
+++ b/tools/KeepBestLinesInDataFile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -106,10 +106,10 @@ with open(args.out_file, "w") as f:
   if args.header:
     f.write(header)
   if args.order_by_id:
-    for value in sorted(rows_to_keep.values(),
+    for value in sorted(list(rows_to_keep.values()),
     key=lambda x: x[0].split(",", 1)[0]):
       f.write(value[0])
   else:
-    for value in rows_to_keep.values():
+    for value in list(rows_to_keep.values()):
       f.write(value[0])
 

--- a/tools/LinkIdentityToCoverage.py
+++ b/tools/LinkIdentityToCoverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -171,7 +171,7 @@ for pos in range(RefLength):
 # position-that-has-that-coverage) by that total number of reads gives the mean
 # identity for that coverage.
 outstring = 'Coverage,Number of positions with that coverage,Mean identity'
-for coverage, count in sorted(CoverageCounts.items(), key=lambda x: x[0]):
+for coverage, count in sorted(list(CoverageCounts.items()), key=lambda x: x[0]):
   TotalNumReads = coverage * count
   MeanIdentity = float(IdentityTotalsByCoverage[coverage]) / TotalNumReads
   outstring += '\n' + str(coverage) + ',' + str(count) + ',' + str(MeanIdentity)

--- a/tools/LinkIdentityToCoverage_CombineBams.py
+++ b/tools/LinkIdentityToCoverage_CombineBams.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -153,7 +153,7 @@ if args.csv_for_replotting == None:
   y = np.empty(len(CoverageCounts))
   NumbersOfPositionsExceedingCoverages = np.empty(len(CoverageCounts))
   RunningTotalNumberOfPositions = 0
-  for i, (coverage, count) in enumerate(sorted(CoverageCounts.items(),
+  for i, (coverage, count) in enumerate(sorted(list(CoverageCounts.items()),
   key = lambda x : x[0], reverse = True)):
     x[i] = coverage
     y[i] = ScaledTotalIdentitiesByCoverage[coverage] / count

--- a/tools/MergeAlignments.py
+++ b/tools/MergeAlignments.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251 
@@ -81,8 +81,8 @@ for InputFile in [MainAlnFile, PairedAlnFile]:
 
 # Read in the sequences from the main alignment file (into a dictionary)
 MainAlnSeqDict, MainAlnSeqLength = ReadSequencesFromFile(MainAlnFile)
-MainAlnSeqNames = MainAlnSeqDict.keys()
-MainAlnSeqs     = MainAlnSeqDict.values()
+MainAlnSeqNames = list(MainAlnSeqDict.keys())
+MainAlnSeqs     = list(MainAlnSeqDict.values())
 
 
 # Read in the sequences from the paired alignment file
@@ -93,7 +93,7 @@ if len(PairedAlnSeqDict) != 2:
   print('File', PairedAlnFile, 'contains', len(PairedAlnSeqDict),\
   'sequences; two were expected.\nQuitting.', file=sys.stderr)
   exit(1)
-Seq1name, Seq2name = PairedAlnSeqDict.keys()
+Seq1name, Seq2name = list(PairedAlnSeqDict.keys())
 
 # Check that one of the sequences is in the main alignment file (the 'Ref')
 # and one is not (the 'SeqToAdd').
@@ -178,7 +178,7 @@ for MainPosition,BaseInMainRef in enumerate(RefSeqFromMain):
     EveryBaseHereIsAGap = False
     if ExciseUniqueInsertionsOfRefInMainAlignment:
       EveryBaseHereIsAGap = True
-      for SeqName, seq in MainAlnSeqDict.items():
+      for SeqName, seq in list(MainAlnSeqDict.items()):
         if SeqName == RefSeqName:
           continue
         elif seq[MainPosition] != GapChar:
@@ -195,7 +195,7 @@ for MainPosition,BaseInMainRef in enumerate(RefSeqFromMain):
     RefInMainHasUniqueInsertion = False
     if ExciseUniqueInsertionsOfRefInMainAlignment:
       RefInMainHasUniqueInsertion = True
-      for SeqName, seq in MainAlnSeqDict.items():
+      for SeqName, seq in list(MainAlnSeqDict.items()):
         if SeqName == RefSeqName:
           continue
         elif seq[MainPosition] != GapChar:
@@ -222,7 +222,7 @@ FinalSeqToAdd = PropagateNoCoverageChar(SeqToAdd_WithGaps)
 # Thanks Stackoverflow:
 def insert_newlines(string, every=FastaSeqLineLength):
     lines = []
-    for i in xrange(0, len(string), every):
+    for i in range(0, len(string), every):
         lines.append(string[i:i+every])
     return '\n'.join(lines)
 

--- a/tools/MergeAlignmentsToCsv.py
+++ b/tools/MergeAlignmentsToCsv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/MergeBaseFreqsAndCoords.py
+++ b/tools/MergeBaseFreqsAndCoords.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/PrintSeqLengths.py
+++ b/tools/PrintSeqLengths.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/QuantifyPairwiseIndels.py
+++ b/tools/QuantifyPairwiseIndels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -144,7 +144,7 @@ def ProcessRangeOfSeqs(SeqNumbers):
       seq1sub = seq1[start : end + 1]
       seq2sub = seq2[start : end + 1]
 
-      for pos, (gap1, gap2) in enumerate(itertools.izip(seq1sub, seq2sub)):
+      for pos, (gap1, gap2) in enumerate(zip(seq1sub, seq2sub)):
 
         # The first position in the pairwise alignment.
         if not pos:
@@ -203,7 +203,7 @@ def ProcessRangeOfSeqs(SeqNumbers):
   return DelSizeCounts, DelPositionCounts
   
 # Do all the pairwise comparisons!
-DelSizeCounts, DelPositionCounts = ProcessRangeOfSeqs(range(NumSeqs))
+DelSizeCounts, DelPositionCounts = ProcessRangeOfSeqs(list(range(NumSeqs)))
 
 def FillInCounterBlanksAndRescale(counter):
   '''Rescale all values by n(n-1)/2 and supply zero for missing values.'''
@@ -221,7 +221,7 @@ FillInCounterBlanksAndRescale(DelSizeCounts)
 # 1-based. NB the map from aln coords to ref coords is many-to-one.
 if args.reference:
   DelRefPositionCounts = Counter()
-  for DelPosition, DelPositionCount in DelPositionCounts.items():
+  for DelPosition, DelPositionCount in list(DelPositionCounts.items()):
     RefPos = AlnPosToRefPos[DelPosition]
     DelRefPositionCounts[RefPos] += DelPositionCount
   DelPositionCounts = DelRefPositionCounts
@@ -231,20 +231,20 @@ else:
     offset = 1 + args.offset
   else:
     offset = 1 
-  for DelPosition, DelPositionCount in DelPositionCounts.items():
+  for DelPosition, DelPositionCount in list(DelPositionCounts.items()):
     DelPositionCountsNew[DelPosition + offset] = DelPositionCount
   DelPositionCounts = DelPositionCountsNew
 
 # Write output  
 with open(args.OutputFileBasename + '_IndelSizes.csv', 'w') as f:
   f.write('Indel size (bp),Mean number of indels of that size per compared pair of sequences\n')
-  for DelSize, DelSizeCount in DelSizeCounts.items():
+  for DelSize, DelSizeCount in list(DelSizeCounts.items()):
     f.write(str(DelSize) + ',' + str(DelSizeCount) + '\n')
 with open(args.OutputFileBasename + '_IndelPositions.csv', 'w') as f:
   if args.reference:
     f.write('Indel pos in ' + args.reference + ',Count\n')
   else:
     f.write('Indel pos in alignment,Count\n')
-  for DelPosition, DelPositionCount in DelPositionCounts.items():
+  for DelPosition, DelPositionCount in list(DelPositionCounts.items()):
     f.write(str(DelPosition) + ',' + str(DelPositionCount) + '\n')
 

--- a/tools/RecoverAlteredUpperLowerCase.py
+++ b/tools/RecoverAlteredUpperLowerCase.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/RemoveBlankColumns.py
+++ b/tools/RemoveBlankColumns.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/RemoveDivergentReads.py
+++ b/tools/RemoveDivergentReads.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/RemoveEmptySeqs.py
+++ b/tools/RemoveEmptySeqs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/ShiverFuncs.py
+++ b/tools/ShiverFuncs.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import sys
 
 def CalculateReadIdentity(PysamRead, ReferenceSeq):
@@ -62,7 +62,7 @@ def RemoveBlankColumns(alignment, BlankChars="-", RemoveUninformative=False):
   any column that is 'uninformative' (all non-blank characters are the same).'''
 
   AlignmentLength = alignment.get_alignment_length()
-  for column in reversed(xrange(AlignmentLength)):
+  for column in reversed(range(AlignmentLength)):
     RemoveThisCol = True
     FirstBaseSeen = None
     for base in alignment[:, column]:

--- a/tools/SplitFasta.py
+++ b/tools/SplitFasta.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251
@@ -78,5 +78,5 @@ if SeqDict == {}:
   exit(1)
 
 # Write the files.
-for FilenameSafeID, seq in SeqDict.items():
+for FilenameSafeID, seq in list(SeqDict.items()):
   SeqIO.write(seq, FilenameFromSeqID(FilenameSafeID), "fasta")

--- a/tools/TranslateSeqForGlobalAln.py
+++ b/tools/TranslateSeqForGlobalAln.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251

--- a/tools/UngapFasta.py
+++ b/tools/UngapFasta.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+
 
 ## Author: Chris Wymant, chris.wymant@bdi.ox.ac.uk
 ## Acknowledgement: I wrote this while funded by ERC Advanced Grant PBDR-339251


### PR DESCRIPTION
We currently use Shiver as part of a larger pipeline. We were having problems getting an easy installation of everything working because of Shiver's dependence on python2. Here I've got a working version of Shiver with python3, achieved by:

- Using python3's `2to3` utility: `for i in *.py; do 2to3 -p -w ${i}; done`
- Updating all cases of "$python2" to "$python"
- Editing the shebangs to be "#!/usr/bin/env python"

Additionally, I've added the option to simplify the installation of all dependencies using `conda` + `mamba`.

Given that `python2` has reached its end of life 3+ years ago (https://www.python.org/doc/sunset-python-2/), it'd be great to have Shiver updated to `python3`.

Thanks!